### PR TITLE
chore: modify ssh agent command

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -17,9 +17,8 @@ jobs:
       - name: Set up SSH agent
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.EC2_SSH_PRIVATE_KEY }}" | tr -d '\r' > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
           ssh-keyscan -H your-ec2-public-ip >> ~/.ssh/known_hosts
 
       - name: Deploy via SSH


### PR DESCRIPTION
- Add flag to handle Windows-style carriage returns, which can corrupt the key when copied into GitHub Secrets.